### PR TITLE
Fix memory leak in SharpCIfs.Util.Sharpen.Thread

### DIFF
--- a/SharpCifs.SMBv1/Util/Sharpen/Thread.cs
+++ b/SharpCifs.SMBv1/Util/Sharpen/Thread.cs
@@ -263,6 +263,7 @@ namespace SharpCifs.Util.Sharpen
             //Log.Out("Thread.Dispose");
 
             this._runnable = null;
+            this._tgroup?.Remove(this);
             this._tgroup = null;
             this._task = null;
             this._canceller?.Dispose();


### PR DESCRIPTION
Fix SharpCIfs.Util.Sharpen.Thread never being removed from ThreadGroups when thread is cancelled.
This fixes application-level memory leak, caused by disposed but never removed Threads in default static ThreadGroup SharpCIfs.Util.Sharpen.Thread.DefaultGroup.