### PR TITLE
Fix thread-lock in Thread

### DIFF
--- a/SharpCifs.SMBv1/Util/Transport/Transport.cs
+++ b/SharpCifs.SMBv1/Util/Transport/Transport.cs
@@ -185,7 +185,7 @@ namespace SharpCifs.Util.Transport
                 catch (Exception ex)
                 {
                     string msg = ex.Message;
-                    bool timeout = msg != null && msg.Equals("Read timed out");
+                    bool timeout = ex is TimeoutException;
                     bool hard = timeout == false;
 
                     if (!timeout && Log.Level >= 3)


### PR DESCRIPTION
Fix thread-lock in Thread.Start() in some cases where _isRunning is never set to true or reset to false while sleeping causing endless loop checking _isRunning